### PR TITLE
GITBOOK-1: Fix typo

### DIFF
--- a/masternode/run-a-full-node/create-a-tomochain-masternode.md
+++ b/masternode/run-a-full-node/create-a-tomochain-masternode.md
@@ -9,9 +9,9 @@ description: >-
 
 Using create-tomochain-masternode and docker-compose offers you benefits like:
 
-* working "out of the box" docker-compose configuration
-* auto-restarting your node on failure
-* flexible configuration (storage, logging, ports)
+* Working "out of the box" docker-compose configuration
+* Auto-restarting your node on failure
+* Flexible configuration (storage, logging, ports)
 
 ### Prerequisites <a href="#prerequisites" id="prerequisites"></a>
 


### PR DESCRIPTION
Fix typo in `create master node doc`